### PR TITLE
chore: update local action references

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # https://github.com/pnpm/action-setup/releases/tag/v6.0.8
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # https://github.com/pnpm/action-setup/releases/tag/v6.0.9
       name: Install pnpm
       with:
         run_install: false


### PR DESCRIPTION
This PR updates third-party GitHub Action references used by `.github/actions/**/action.yml`.

Generated automatically by the `update-local-action-uses` workflow because Dependabot does not update `uses:` entries inside local composite actions.