### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   ],
   "engines": {
     "node": ">=24",
-    "pnpm": "^11.6.0"
+    "pnpm": "^11.7.0"
   },
-  "packageManager": "pnpm@11.6.0"
+  "packageManager": "pnpm@11.7.0"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `.github/actions/**/action.yml`
- workflows that bootstrap Node.js directly

Resolved by automation:
- Node.js major: `24`
- pnpm version: `11.7.0`